### PR TITLE
Add a Cloud Run task to generate map tiles

### DIFF
--- a/tasks/generate_property_map_tiles/Dockerfile
+++ b/tasks/generate_property_map_tiles/Dockerfile
@@ -1,0 +1,26 @@
+# This Dockerfile is a mix of two documentation sources:
+# https://cloud.google.com/run/docs/quickstarts/jobs/build-create-shell#writing
+# https://cloud.google.com/run/docs/tutorials/gcloud#code-container
+
+# ----------
+
+# Use a gcloud image based on debian:buster-slim for a lean production container.
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+
+RUN apt-get update
+
+# Install GDAL for ogr2ogr
+RUN apt-get install -y gdal-bin
+
+# Execute next commands in the directory /workspace
+WORKDIR /workspace
+
+# Copy over the script to the /workspace directory
+COPY script.sh .
+
+# Just in case the script doesn't have the executable bit set
+RUN chmod +x ./script.sh
+
+# Run the script when starting the container
+CMD [ "./script.sh" ]

--- a/tasks/generate_property_map_tiles/script.sh
+++ b/tasks/generate_property_map_tiles/script.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Download the property_tile_info.geojson file from the temp bucket.
+gcloud storage cp \
+  gs://musa509s23_team01_temp_data/property_tile_info.geojson \
+  ./property_tile_info.geojson
+
+# Convert the geojson file to a vector tileset in a folder named "properties".
+# The tile set will be in the range of zoom levels 12-18. See the ogr2ogr docs
+# at https://gdal.org/drivers/vector/mvt.html for more information.
+ogr2ogr \
+  -f MVT \
+  -dsco MINZOOM=12 \
+  -dsco MAXZOOM=18 \
+  -dsco COMPRESS=NO \
+  ./properties \
+  ./property_tile_info.geojson
+
+# Upload the vector tileset to the public bucket.
+gcloud storage cp \
+  --recursive \
+  ./properties \
+  gs://musa509s23_team01_public/tiles


### PR DESCRIPTION
See Issue #14 for more detail.

To deploy this Run job, use the following commands:

```bash
gcloud builds submit \
  --region us-central1 \
  --tag gcr.io/musa509s23-team1-philly-cama/generate-property-map-tiles

# Note, if the job already exists, you have to change "create" to "update" below.
gcloud beta run jobs create generate-property-map-tiles \
  --image gcr.io/musa509s23-team1-philly-cama/generate-property-map-tiles \
  --service-account data-pipeline-user@musa509s23-team1-philly-cama.iam.gserviceaccount.com \
  --cpu 4 \
  --memory 2Gi \
  --region us-central1