### PR TITLE
Add transform steps to workflow

### DIFF
--- a/tasks/data_pipeline.yaml
+++ b/tasks/data_pipeline.yaml
@@ -43,3 +43,22 @@ main:
                             url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/load-opa-assessments
                             auth:
                                 type: OIDC
+    - transform:
+        parallel:
+            branches:
+            - current_assessments:
+                steps:
+                - train_model: {}
+                - transform_current_assessment_bins: {}
+            - tax_year_assessments:
+                steps:
+                - transform_tax_year_assessment_bins: {}
+    - generate_site_data:
+        parallel:
+            branches:
+            - chart_configs:
+                steps:
+                - generate_assessment_chart_configs: {}
+            - map_tiles:
+                steps:
+                - generate_property_map_tiles: {}

--- a/tasks/data_pipeline.yaml
+++ b/tasks/data_pipeline.yaml
@@ -43,22 +43,46 @@ main:
                             url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/load-opa-assessments
                             auth:
                                 type: OIDC
-    - transform:
-        parallel:
-            branches:
-            - current_assessments:
-                steps:
-                - train_model: {}
-                - transform_current_assessment_bins: {}
-            - tax_year_assessments:
-                steps:
-                - transform_tax_year_assessment_bins: {}
+    - train_model: {}
     - generate_site_data:
         parallel:
             branches:
             - chart_configs:
                 steps:
-                - generate_assessment_chart_configs: {}
+                - transform_current_assessment_bins:
+                    call: http.post
+                    args:
+                        url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/transform-current-assessment-bins
+                        auth:
+                            type: OIDC
+                - transform_tax_year_assessment_bins:
+                    call: http.post
+                    args:
+                        url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/transform-tax-year-assessment-bins
+                        auth:
+                            type: OIDC
+                - generate_assessment_chart_configs:
+                    call: http.post
+                    args:
+                        url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/generate-assessment-chart-configs
+                        auth:
+                            type: OIDC
             - map_tiles:
                 steps:
-                - generate_property_map_tiles: {}
+                - transform_property_tile_info:
+                    call: http.post
+                    args:
+                        url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/transform-property-tile-info
+                        auth:
+                            type: OIDC
+                - export_property_tile_info:
+                    call: http.post
+                    args:
+                        url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/export-property-tile-info
+                        auth:
+                            type: OIDC
+                - generate_property_map_tiles:
+                    call: googleapis.run.v1.namespaces.jobs.run
+                    args:
+                        name: namespaces/musa509s23-team1-philly-cama/jobs/generate-property-map-tiles
+                        location: us-central1

--- a/tasks/data_pipeline.yaml
+++ b/tasks/data_pipeline.yaml
@@ -1,6 +1,6 @@
 main:
     steps:
-    - parallelStep:
+    - extract_and_load:
         parallel:
             branches:
             - properties:
@@ -23,21 +23,21 @@ main:
                         url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/load-properties
                         auth:
                             type: OIDC
-            - accessments:
+            - assessments:
                 steps:
-                    - extract_opa_accessments:
+                    - extract_opa_assessments:
                         call: http.post
                         args:
                             url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/extract-opa-assessments
                             auth:
                                 type: OIDC
-                    - prepare_opa_accessments:
+                    - prepare_opa_assessments:
                         call: http.post
                         args:
                             url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/prepare-opa-assessments
                             auth:
                                 type: OIDC
-                    - load_opa_accessments:
+                    - load_opa_assessments:
                         call: http.post
                         args:
                             url: https://us-central1-musa509s23-team1-philly-cama.cloudfunctions.net/load-opa-assessments

--- a/tasks/env.yaml
+++ b/tasks/env.yaml
@@ -1,0 +1,1 @@
+GCP_PROJECT: musa509s23-team1-philly-cama

--- a/tasks/export_property_tile_info/main.py
+++ b/tasks/export_property_tile_info/main.py
@@ -1,0 +1,67 @@
+import decimal
+import json
+import os
+import pathlib
+import functions_framework
+from google.cloud import bigquery
+from google.cloud import storage
+
+ROOT = pathlib.Path(__file__).parent
+
+
+class MoneyEncoder(json.JSONEncoder):
+    """
+    JSON encoder to convert a decimal.Decimal object to a string when encoding.
+    This is necessary because lower and upper bounds on bins will use the
+    Decimal type (instead of int or float), and the default Python JSON encoder
+    does not know how to handle this type.
+    """
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            return round(float(o), 2)
+        return super().encode(o)
+
+
+@functions_framework.http
+def export_temp_data(request):
+    bigquery_client = bigquery.Client()
+    project_id = os.environ['GCP_PROJECT']
+    dataset_id = 'derived'
+
+    storage_client = storage.Client()
+    bucket_name = 'musa509s23_team01_temp_data'
+    bucket = storage_client.bucket(bucket_name)
+
+    # Convert table rows to GeoJSON features
+    table_id = 'property_tile_info'
+    query = f'''
+        SELECT * FROM {project_id}.{dataset_id}.{table_id}
+    '''
+    query_job = bigquery_client.query(query)
+    rows = query_job.result()
+
+    features = []
+    for row in rows:
+        feature = {
+            'type': 'Feature',
+            'properties': {
+                attr: val
+                for attr, val in row.items()
+                if attr != 'geog_json'
+            },
+            'geometry': json.loads(row['geog_json'])
+        }
+        features.append(feature)
+    json_data = json.dumps({
+        'type': 'FeatureCollection',
+        'features': features
+    }, cls=MoneyEncoder)
+
+    blob = bucket.blob('property_tile_info.geojson')
+    blob.upload_from_string(json_data, content_type='application/json')
+
+    return 'GeoJSON file generated and uploaded to Cloud Storage', 200
+
+
+if __name__ == '__main__':
+    export_temp_data('test')

--- a/tasks/export_property_tile_info/requirements.txt
+++ b/tasks/export_property_tile_info/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.3.*
+google-cloud-bigquery==3.10.*
+google-cloud-storage==2.8.*

--- a/tasks/transform_property_tile_info/create_derived_property_tile_info.sql
+++ b/tasks/transform_property_tile_info/create_derived_property_tile_info.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE TABLE `derived.property_tile_info` AS
+
+WITH `latest_tax_year` AS (
+    SELECT MAX(`year`) AS `year`
+    FROM `core.opa_assessments`
+)
+
+SELECT
+    curr.`property_id`,
+    parcels.`address`,
+    ST_ASGEOJSON(parcels.`geog`) AS `geog_json`,
+    curr.`assessed_value` AS `current_assessed_value`,
+    past.`market_value` AS `tax_year_assessed_value`
+FROM `derived.current_assessments` AS curr
+INNER JOIN `core.pwd_parcels` AS parcels USING (`property_id`)
+LEFT JOIN `core.opa_assessments` AS past USING (`property_id`)
+CROSS JOIN `latest_tax_year`
+WHERE
+    past.`property_id` IS NULL
+    OR past.`year` = `latest_tax_year`.`year`

--- a/tasks/transform_property_tile_info/main.py
+++ b/tasks/transform_property_tile_info/main.py
@@ -1,0 +1,24 @@
+# The python code for cloud function (Task 08)
+
+import os
+import pathlib
+import functions_framework
+from google.cloud import bigquery
+
+ROOT = pathlib.Path(__file__).parent
+
+
+@functions_framework.http
+def generate_derived_table(request):
+    project_id = os.environ['GCP_PROJECT']
+
+    # Read the SQL query from the file
+    with open(ROOT / 'create_derived_property_tile_info.sql', 'r') as sql_file:
+        sql_query = sql_file.read()
+
+    # Run the SQL query
+    client = bigquery.Client(project=project_id)
+    query_job = client.query(sql_query)
+    query_job.result()
+
+    return 'Table generated successfully', 200

--- a/tasks/transform_property_tile_info/requirements.txt
+++ b/tasks/transform_property_tile_info/requirements.txt
@@ -1,0 +1,2 @@
+functions-framework==3.3.*
+google-cloud-bigquery==3.10.*


### PR DESCRIPTION
Workflow can be re-deployed with the following command:

```
gcloud workflows deploy data-pipeline \
  --source tasks/data_pipeline.yaml \
  --location us-central1 \
  --service-account data-pipeline-user@musa509s23-team1-philly-cama.iam.gserviceaccount.com
```

Also present in this PR are functions for generating input information for property tiles. They can be deployed with:

```
gcloud functions deploy transform-property-tile-info \
  --source tasks/transform_property_tile_info \
  --entry-point generate_derived_table \
  --env-vars-file=tasks/env.yaml \
  --region us-central1 \
  --runtime python311 \
  --trigger-http \
  --timeout=540s \
  --no-allow-unauthenticated \
  --service-account data-pipeline-user@musa509s23-team1-philly-cama.iam.gserviceaccount.com

gcloud functions deploy export-property-tile-info \
  --source tasks/export_property_tile_info \
  --entry-point export_temp_data \
  --env-vars-file=tasks/env.yaml \
  --region us-central1 \
  --runtime python311 \
  --trigger-http \
  --timeout=540s \
  --no-allow-unauthenticated \
  --service-account data-pipeline-user@musa509s23-team1-philly-cama.iam.gserviceaccount.com
```